### PR TITLE
Change filter name

### DIFF
--- a/classic-widgets.php
+++ b/classic-widgets.php
@@ -30,4 +30,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Disables the block editor from managing widgets in the Gutenberg plugin.
 add_filter( 'gutenberg_use_widgets_block_editor', '__return_false' );
 // Disables the block editor from managing widgets.
-add_filter( 'wp_use_widgets_block_editor', '__return_false' );
+add_filter( 'use_widgets_block_editor', '__return_false' );


### PR DESCRIPTION
As of https://github.com/WordPress/wordpress-develop/commit/00bc227eb8e7b09e9eb6390a74a23a3f3fcc2383 the filter name has now changed to `use_widgets_block_editor` from `wp_use_widgets_block_editor`