### PR TITLE
6.1 updates

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg, hellofromtonya, azaozz
 Tags: gutenberg, disable, disable gutenberg, editor, classic widgets
 Requires at least: 4.9
-Tested up to: 5.9
+Tested up to: 6.1
 Stable tag: 0.3
 Requires PHP: 5.6 or later
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Enables the previous "classic" widgets settings screens in Appearance - Widgets 
 
 == Description ==
 
-Classic Widgets is an official plugin maintained by the WordPress team that restores the previous ("classic") WordPress widgets settings screens. It will be supported and maintained until at least 2022, or as long as is necessary.
+Classic Widgets is an official plugin maintained by the WordPress team that restores the previous ("classic") WordPress widgets settings screens. It will be supported and maintained for as long as is necessary.
 
 Once activated and when using a classic (non-block) theme, this plugin restores the previous widgets settings screens and disables the block editor from managing widgets. There is no other configuration, the classic widgets settings screens are enabled or disabled by either enabling or disabling this plugin.
 

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Enables the previous "classic" widgets settings screens in Appearance - Widgets 
 
 == Description ==
 
-Classic Widgets is an official plugin maintained by the WordPress team that restores the previous ("classic") WordPress widgets settings screens. It will be supported and maintained for as long as is necessary.
+Classic Widgets is an official plugin maintained by the WordPress team that restores the previous ("classic") WordPress widgets settings screens. It will be supported and maintained until at least 2022, or as long as is necessary.
 
 Once activated and when using a classic (non-block) theme, this plugin restores the previous widgets settings screens and disables the block editor from managing widgets. There is no other configuration, the classic widgets settings screens are enabled or disabled by either enabling or disabling this plugin.
 


### PR DESCRIPTION
- Raises "Tested up to" to 6.1.
- ~Removes reference to 2022 in description. The plugin will be maintained for as long as needed.~

Plugin version remains unmodified to prevent unnecessary plugin updates.